### PR TITLE
Add conversion engine and tests

### DIFF
--- a/utils/__tests__/conversionEngine.test.ts
+++ b/utils/__tests__/conversionEngine.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { findConversionPath } from '../conversionEngine';
+
+describe('conversion engine', () => {
+  it('detects optimal direct conversion', () => {
+    const result = findConversionPath('mp3', 'wav');
+    expect(result.optimal).toBe(true);
+    expect(result.path).toEqual(['mp3', 'wav']);
+  });
+
+  it('finds intermediate path when direct conversion missing', () => {
+    const result = findConversionPath('flac', 'aac');
+    expect(result.optimal).toBe(false);
+    expect(result.path).toEqual(['flac', 'mp3', 'aac']);
+  });
+
+  it('returns null path when no conversion possible', () => {
+    const result = findConversionPath('mp3', 'docx');
+    expect(result.path).toBeNull();
+    expect(result.optimal).toBe(false);
+  });
+});

--- a/utils/conversionEngine.ts
+++ b/utils/conversionEngine.ts
@@ -1,0 +1,63 @@
+import { getFileCategory } from './conversionMaps';
+
+export type ConversionMatrix = Record<string, string[]>;
+
+const intraCategoryMatrix: ConversionMatrix = {
+  mp3: ['wav', 'aac'],
+  wav: ['mp3', 'flac'],
+  flac: ['mp3'],
+  mp4: ['webm', 'mov'],
+  mov: ['mp4'],
+  png: ['jpg', 'webp'],
+  jpg: ['png', 'webp'],
+  docx: ['pdf', 'txt'],
+  pdf: ['docx'],
+};
+
+const interCategoryMatrix: ConversionMatrix = {
+  jpg: ['pdf'],
+  png: ['pdf'],
+  mp3: ['mp4'],
+  docx: ['jpg'],
+};
+
+const combinedMatrix: ConversionMatrix = { ...intraCategoryMatrix };
+for (const [src, targets] of Object.entries(interCategoryMatrix)) {
+  combinedMatrix[src] = [...(combinedMatrix[src] || []), ...targets];
+}
+
+export interface ConversionResult {
+  optimal: boolean;
+  path: string[] | null;
+}
+
+function bfs(start: string, goal: string): string[] | null {
+  if (start === goal) return [start];
+  const queue: [string, string[]][] = [[start, [start]]];
+  const visited = new Set<string>([start]);
+
+  while (queue.length > 0) {
+    const [current, path] = queue.shift()!;
+    const neighbors = combinedMatrix[current.toLowerCase()] || [];
+    for (const next of neighbors) {
+      if (visited.has(next)) continue;
+      const newPath = [...path, next];
+      if (next === goal) return newPath;
+      visited.add(next);
+      queue.push([next, newPath]);
+    }
+  }
+  return null;
+}
+
+export function findConversionPath(sourceExt: string, targetExt: string): ConversionResult {
+  const path = bfs(sourceExt.toLowerCase(), targetExt.toLowerCase());
+  return {
+    optimal: path !== null && path.length === 2,
+    path,
+  };
+}
+
+export function canConvert(sourceExt: string, targetExt: string): boolean {
+  return bfs(sourceExt.toLowerCase(), targetExt.toLowerCase()) !== null;
+}


### PR DESCRIPTION
## Summary
- implement `conversionEngine` to search for conversion paths
- add unit tests for conversion engine

## Testing
- `npx vitest run` *(fails: Header, FormatSelector, and App tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_6871ee21f5948320a3745e47376aa544